### PR TITLE
RDKEMW-16984 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1580

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="aec1a2c88700eb4e38a17ad1da4616058dfd6207">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="3fca90fa8ae735df5f33e3efd486d1606ab19b73">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: Reason for change: When Firebolt Display APIs are called logs are not get recorded in weframework.log
Test Procedure: Check the wpeframework logs
Risks: Low
Priority: P1
version: Patch
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: adfb49e4cae0033ebb8927127a05155e285396e1



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: 3fca90fa8ae735df5f33e3efd486d1606ab19b73
