### PR TITLE
RDKEMW-18677 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1765

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="80bfcbab9c9a87eb93e7089495b43c6b31bc94f2">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="c401be10b5664282e447815b5060a02f4f2683e2">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: RDKEMW-18677: Protect MediaCapabilities JS wrapper from GC

Add GenerateIsReachable=ReachableFromNavigator to prevent wrapper GC.
The MediaCapabilities interface is annotated [SameObject] in the spec,
meaning navigator.mediaCapabilities must return the same object on every
access. Without GC protection, the JS wrapper can be collected when no
JS reference holds it, causing a new wrapper to be created on next access.
This breaks object identity and loses any user-set properties.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 3dc0008d76a6845e1014ef53f5b8d8c093e39d5e



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: c401be10b5664282e447815b5060a02f4f2683e2
