### PR TITLE
RDKEMW-18818 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1863

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="c3269f7c5630120d67379151549248278e7d857c">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="f8b8bed80a9e1f691bc41b8fb98a16bbe5f0ae67">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: Reason for change - The NTP servers are configured using the server directive in chrony.conf. With this configuration, DNS resolution occurs only once during startup, and Chrony selects one of the resolved IP addresses. If the selected address is an IPv6 address, Chrony sends NTP requests to the server, but no response is received.

Configure the NTP servers using the pool directive instead of the server directive. The pool directive performs periodic DNS re-resolution of the configured hostnames, allowing Chrony to select alternate addresses when needed, which effectively mitigates the issue.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 1d01dbc1a92a686bd27a465525447d668de5e1bc
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 1cf855e05df78eb4d27d905e60cc33fe92f5d8f5



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: f8b8bed80a9e1f691bc41b8fb98a16bbe5f0ae67
