### PR TITLE
RDKEMW-19048 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1877

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="9f9aff20f9d5a874ba550a5d86cd63f17b35d22d">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="a3ee60a1babbe967462d747d19ffc8bbe50aca35">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: Finalization PR for the RDKEMW-19048 deep-sleep SecAPI handle set on develop.

Three commits:

1. **wpeframework-clientlibraries r4.4 patch** - `0002-RDKEMW-19048-Release-and-reacquire-Vault-SecProcessor-for-deep-sleep.patch`, a squash of the former 0002 wrapper patch (this PR's original content) and the 0003 reacquire patch (#4297, now closed). Verified to produce a byte-identical patched tree to applying the two originals in sequence. Adds `vault_processor_release()` C wrapper for the CryptographyExtAccess plugin, and reacquires the SecProcessor at Vault method entry so cached `VaultImplementation*` holders do not crash after release.
2. **entservices-cryptography 1.0.2 -> 1.0.5** (SRCREV `d95807fac4b50ae036aeb1486b0be0dc3142ea93`) - 1.0.5 carries entservices-cryptography#12 (release Vault singleton SecProcessor handle on deep sleep). Intermediate 1.0.3/1.0.4 are CI-workflow/header changes only.
3. **thunderstartupservices 1.3.6 -> 1.3.9** (SRCREV `a46ca7149fabe6e441903bea4ecf8bf937ca5efa`) - 1.3.9 carries thunder-startup-services#240 (order org.rdk.Cryptography activation after org.rdk.PowerManager). 1.3.7/1.3.8 in between bring a packagemanager unit tweak and the new appactions unit (RDKEMW-17106).

DevQA builds (MW `middleware-dbg/RDKEMW-19048-5`, all five arch feeds) carry exactly this content; rootfs content-verified on Sky Llama Panel and XiOne Xfinity Stream Box images.

Version: patch

Resolves rdkcentral/meta-rdk-video#4400


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 14375b7dfd36617344eccf7268e656f9fea409cd



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: a3ee60a1babbe967462d747d19ffc8bbe50aca35
