### PR TITLE
RDKEMW-18836 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1899

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="318ee94087b99c21408105fa6d4fbd03d3508e26">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="c518a1deed8298c6c724daa9317cb19255325dec">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: Update entservices-monitor to 1.1.0. Its main feature is ability to configure the list of configured plugins from the recipe, using the PLUGIN_MONITOR_INSTANCES_LIST variable.
Cleaned up the recipe for a lot of unused and unsupported leftovers from plugin split (entservices-infra to individual projects). TextToSpeech configuration is now set in the recipe rather than in source code.



List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 19aa224f30fbc4fddd8a7bef498dc0ecbe6f672c



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: c518a1deed8298c6c724daa9317cb19255325dec
