### PR TITLE
RDK-61847 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1940

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="cba336faabfba08870833dc4f89456cb6e479216">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="6ae7b89a9c0c1ccbdc6729167a5e702c3f620e43">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: RDK-61847: wpe-webkit 2.46.2 minor upgrade

Bring the latest WPEWebKit wpe-2.46 revision:
* Missing video in WebRTC playback when decoding on playback pipeline
* Additional H.264 encode profile/level advertisement.
* MediaCapabilities GC lifetime fix.
* WASM 64b build fix
* Canvas capture stream rendering and timing fixes in GStreamer path.

Remove obsolete wpe-webkit_2.46 base recipe.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 075369a8882dd03be10ee099f7b16d7041933cea



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: 6ae7b89a9c0c1ccbdc6729167a5e702c3f620e43
