### PR TITLE
RDKEMW-19501 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1956

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="1a4d951a661617186e431817818aff8a1046797b">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="b8cc596730c821ca48bc4863f600d7d69b93a2fd">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: Reason for change:  Extend the advertised/accepted H.264 profile-level-id set to cover additional profile families and levels seen in offers, preventing WebRTC playback failures during SDP negotiation.
Test Procedure: Validate a sample app with multiple profile level family given in offer
Priority: P1
Risks: None


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: f3e37f06a18920aa7e344fe157997651c789ac36



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: b8cc596730c821ca48bc4863f600d7d69b93a2fd
