### PR TITLE
RDKEMW-20680 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1969

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="925e2634e67fb18b029968f5b9799798c73fecc9">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="b2dcef2e4f4f522a4320266ea2dbf0b2c6862428">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: Follow-up to RDKEMW-19048. That change added `vault_processor_release()` to the SecApi vault backend only; the shared CryptographyExtAccess plugin (entservices-cryptography) calls the symbol unconditionally from `onPowerModeChanged`.

The cryptography library links exactly one backend (`CRYPTOGRAPHY_IMPLEMENTATION = enable_icrypto_openssl ? OpenSSL : SecApi`), so platforms that build the OpenSSL vault (RDKM community: RTK/BCM/RPI) fail to load the plugin with `undefined symbol: vault_processor_release` and cannot enter deep sleep.

Adds a no-op `vault_processor_release()` to the OpenSSL and Thunder backends via a new patch `0003-RDKEMW-20680-vault-processor-release-openssl-thunder-stubs.patch`. Neither backend holds a SecAPI SecProcessor handle across S3, so there is nothing to release - the stub only satisfies the ABI so the plugin loads. SecApi keeps its real handle-releasing implementation (`0002-RDKEMW-19048-...`).

Reported on RDKM (RTD1325); supersedes the dependency workaround in #4564.

Version: patch



List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: ee0613b8ff77261f8c1708036e1e95b26382aaf8



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: b2dcef2e4f4f522a4320266ea2dbf0b2c6862428
