### PR TITLE
RDKEMW-20646 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1974

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="8bcbf3b619eaf400742e6ca2f320138a2d0ca681">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="bce53404d113b4679f54f29b0e19478dddf7d2a5">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: Reason for change:  NetworkManager release v3.4.0 with following fixes
    -> Using dedicated Eventing thread to send the events (#322)
    -> Added telemetry T2 event posting for IPv6 public IP (#325)
    -> LegacyNetworkAPIs logs are not printed under wpeframework logs (#324)
    -> reconnect failure on deepsleep wakeup (#321)
    -> Fix the notification locks in networkmanager plugin (#319)


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 487fed16673dc6c5a12a9c78885bbe416a558ac7



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: bce53404d113b4679f54f29b0e19478dddf7d2a5
