### PR TITLE
RDKEMW-6898 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1980

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="a0b01d96e0f3d96e21e61da7ce492e15ed91ca5a">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="9b2489acdd2cf009f5c41552934c1e4cc7a64508">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: Reason for change: Updated xdial to latest 1.0.4 to support latest version of gssdp 1.6.3.
Test Procedure: Compiled and Verified
Risks: Low
Priority: P1
version: minor


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: fb3540020ab60b6de98ec10b159ca6e02f658f97



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: 9b2489acdd2cf009f5c41552934c1e4cc7a64508
