### PR TITLE
RDKEMW-22558 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 2034

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="71c83fcf0f43d611d6f421e668cdfe0d3ce7e9a9">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="61fbc2a530cb0339c91f5b9fef995daffeb23570">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: What's Changed in Larboard:
RDKEMW-19778 : Refresh Advertising IFA cache after 1 second by @pravakarcomcast in #63 RDKEMW-20128: Set font package name overrides by @umesh-kesavan in #64 RDKMVE-2765 : Subscribe to onStateChanged firebolt lifecycle event by @ansu-mathew in #65 RDKEMW-21711: allow advertising settings setup via overrides by @emutavchi in #66 RDKEMW-22248: Migrate from org.rdk.Network to org.rdk.NetworkManager API by @sranan984 in #67


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 8cc90bd8643c44bb0af53e65b0f0b3ed006988b4



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: 61fbc2a530cb0339c91f5b9fef995daffeb23570
