### PR TITLE
RDKEMW-22493 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 2052

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="61fbc2a530cb0339c91f5b9fef995daffeb23570">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="a866648ebb2e9191e29f4b7cd8ba32e2c57de8fc">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/4.1.4">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details:     Reason for change: The decryptToHost value was being pushed to the SVP context on every decrypt call, adding unnecessary per-frame overhead. Since it is set only once per pipeline and never changes, accept that a single update is sufficient and follow the established decrypt control flow for subsequent calls.

    Test Procedure: Launch a DRM-protected video (e.g. Netflix/Prime), play a video, switch content, and repeat playback about 10 times. Verify secure and decrypt-to-host playback both work correctly with no decryption failures.

    Risks: low
    Priority: P2


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: fe078b2ee1bb55dc37c6324dbd3aa9308aa5639b



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: a866648ebb2e9191e29f4b7cd8ba32e2c57de8fc
