### PR TITLE
RDK-61847 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 2062

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="d05311c95ea24413f191ba71adb8c091ee800882">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="8b613a0d6a29f8ecc6baed5a43b5cfcc22a40c22">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/5.0.0_hotfix">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: RDK-61847: Enable wpe-webkit 2.46 for all RDK-E devices


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: b7525089d833bc120ed2e769397458c83c83fa7a



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: 8b613a0d6a29f8ecc6baed5a43b5cfcc22a40c22
