### PR TITLE
RDKEMW-16128 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 2080

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="09883e54ca6e673a64c84ed6585eeddb5991c89e">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="4340a89354c127c60d6584fcf9a65b470e67b191">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/5.0.0_hotfix">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: **[WPEWebKit][libWebRTC][GStreamer] Missing video in WebRTC playback when decoding on playback pipeline**
Add a mechanism to keep undelivered webRTC frames when they come in an encoded format and there's no registered observer to deliver them to.
Redeliver the frames when the first observer is registered.
This solves the problem of missing WebRTC Video frames causing a black screen in cloud gaming.



List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 06f2c7d3569e4426d4be6b9bcb53e84f0a8736cf



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: 4340a89354c127c60d6584fcf9a65b470e67b191
