### PR TITLE
RDKEMW-23286 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 2086

### DIFF
--- a/rdke-middleware.xml
+++ b/rdke-middleware.xml
@@ -32,7 +32,7 @@
     <project groups="oe" name="meta-python2" path="rdke/middleware/meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2" />
     </project>
-    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="cae8fe8112e0605d8f1818fa3d3966c2e9b3e578">
+    <submanifest name="middleware-generic" project="rdke-middleware-generic-manifest" manifest-name="middleware-generic.xml" path="rdke/middleware/generic" remote="rdkcentral" revision="515012fd8213fe1472588ff872a82f9832da04c8">
     </submanifest>
     <project groups="rdk" name="meta-rdk-halif-headers" path="rdke/common/meta-rdk-halif-headers" remote="rdkcentral" revision="refs/tags/5.0.0_hotfix">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_HALIF_HEADERS" />


### PR DESCRIPTION
Details: Details: 
This pull request addresses a crash in WPE WebKit that occurs when a child
process dies before it can send its PID to the parent process. The main change
is to add a check for this scenario, preventing the parent from crashing and
handling the error gracefully instead. The patch is applied to the build, and
the logic in both the process launcher and IPC connection code is updated.

Crash handling improvements:

- Added a check in readPIDFromPeer (in ConnectionUnix.cpp) to return 0 if the
  child process dies before sending its PID (i.e., if recvmsg() returns 0),
  preventing a crash in the parent process. The parent now detects this
  condition and handles it gracefully.
- Updated ProcessLauncherGLib.cpp to handle a zero PID from readPIDFromPeer by
  stopping the socket monitor, closing the server socket, and emitting a crash
  signal, instead of aborting.

Build system changes:

- Added the new patch (1711.patch) to the SRC_URI in wpe-webkit_2.46.2.bb to
  ensure the fix is applied during the build process.

Upstream patch: WPEWebKit PR #1711
https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1711


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 0ed268f4fd72e4ea3c1eaed8a9be2fbe88d36aca



List of PRs and Repositories Involved:
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: 515012fd8213fe1472588ff872a82f9832da04c8
